### PR TITLE
Feature/dont modify file from rpms

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ Default: `/etc/systemd/system/default.target.wants/haveged.service`
 
 Path to the systemd script on Debian flavours.
 
+####[`haveged_lineinfile`][haveged_lineinfile]
+Default: `True`
+
+Enables modifying haveged.service under multi-user.target.wants or default.target.wants
+
+####[`haveged_systemd_override`][haveged_systemd_override]
+Default: `False`
+
+Template in a systemd override of ExecStart into /etc/systemd/system/haveged.service.d/override.conf
+
 ## Dependencies
 ------------
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,4 +12,7 @@ haveged_config_initd_path: '/etc/init.d/haveged'
 
 haveged_systemd_path_centos: '/etc/systemd/system/multi-user.target.wants/haveged.service'
 haveged_systemd_path_debian: '/etc/systemd/system/default.target.wants/haveged.service'
+
+haveged_lineinfile: True
+haveged_systemd_override: False
 ...

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -7,7 +7,7 @@
   notify:
     - restart haveged
 
-- name: Set as upstart
+- name: start haveged on boot
   service:
     name: haveged
     enabled: yes

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -6,7 +6,7 @@
   notify:
     - restart haveged
 
-- name: Set as upstart
+- name: start haveged on boot
   service:
     name: haveged
     enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,27 @@
     backrefs=yes
     dest="{{ haveged_systemd_path }}"
     state=present
-  when: haveged_systemd is defined and haveged_systemd.stat.exists
+  when: haveged_systemd is defined and haveged_systemd.stat.exists and haveged_lineinfile
+  notify:
+    - restart haveged
+
+- name: create directory for systemd override
+  file: 
+    path: /etc/systemd/system/haveged.service.d 
+    mode: 0755 
+    owner: root
+    group: root
+    state: directory
+  when: haveged_systemd is defined and haveged_systemd.stat.exists and haveged_systemd_override
+
+- name: template in systemd override
+  template:
+    src: "haveged.service.override.conf.j2"
+    dest: "/etc/systemd/system/haveged.service.d/override.conf"
+    mode: "0644"
+    owner: "root"
+    group: "root"
+  when: haveged_systemd is defined and haveged_systemd.stat.exists and haveged_systemd_override
   notify:
     - restart haveged
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
     backrefs=yes
     dest="{{ haveged_systemd_path }}"
     state=present
-  when: haveged_systemd is defined and haveged_systemd.stat.exists and haveged_lineinfile
+  when: haveged_systemd is defined and haveged_systemd.stat.exists and haveged_lineinfile and haveged_systemd_override == False
   notify:
     - restart haveged
 
@@ -31,7 +31,7 @@
     owner: root
     group: root
     state: directory
-  when: haveged_systemd is defined and haveged_systemd.stat.exists and haveged_systemd_override
+  when: haveged_systemd is defined and haveged_systemd.stat.exists and haveged_systemd_override and haveged_lineinfile == False
 
 - name: template in systemd override
   template:
@@ -40,7 +40,7 @@
     mode: "0644"
     owner: "root"
     group: "root"
-  when: haveged_systemd is defined and haveged_systemd.stat.exists and haveged_systemd_override
+  when: haveged_systemd is defined and haveged_systemd.stat.exists and haveged_systemd_override and haveged_lineinfile == False
   notify:
     - restart haveged
 ...

--- a/templates/haveged.service.override.conf.j2
+++ b/templates/haveged.service.override.conf.j2
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/haveged -w {{ haveged_low_entropy_watermark }} -v 1 --Foreground


### PR DESCRIPTION
Hi!

Thanks for a nice role.

I suspect the haveged.service file that this role modifies will be overwritten whenever the rpm is updated, at least it does if one does a "yum reinstall" on CentOS 7.

So instead I'd like to template in a systemd override file into /etc/systemd/system/haveged.service.d/override.conf

To make this work for CentOS7 I had to override {{ haveged_systemd_path_centos }} to point to /lib/systemd/system/haveged.service instead (as in my CentOS7 there is no multi-user symlink). On my debian 8 machine the same above file exists. They both set the same settings for the haveged and anyway the override.conf right now only overrides the ExecStart systemd parameter for the service.

I'd like to make two further changes:

A) Could we change the defaults to point to /lib/systemd/system/haveged.service for both CentOS7 and Debian.

and

B) Can we remove the lineinfile method completely?